### PR TITLE
Authentication type Basic Authentication

### DIFF
--- a/terror-movies-web/src/main/java/com/terrormovies/web/security/ServerErrorFailureHandler.java
+++ b/terror-movies-web/src/main/java/com/terrormovies/web/security/ServerErrorFailureHandler.java
@@ -1,0 +1,26 @@
+package com.terrormovies.web.security;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+
+public class ServerErrorFailureHandler implements AuthenticationFailureHandler {
+
+
+    // AuthenticationFailureHandler Method
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException exception) throws IOException, ServletException {
+        // Set Error Code
+        response.sendError(500, "Server failed to authenticate you!");
+    }
+
+}

--- a/terror-movies-web/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/terror-movies-web/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -5,10 +5,21 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
 
 	<security:http auto-config="true">
-	    <security:form-login login-page="/custom_login" username-parameter="user_param" password-parameter="pass_param" default-target-url="/admin/movies" authentication-failure-url="/custom_login?login_error"/>
+<!--    Configuration for form login authentication -->
+<!-- 
+		<security:form-login login-page="/custom_login"
+			username-parameter="user_param" password-parameter="pass_param"
+			default-target-url="/admin/movies"
+			authentication-failure-url="/custom_login?login_error" authentication-failure-handler-ref="serverErrorHandler"/>
+ -->
+<!-- HTTP Authentication (non-form) :: BasicAuthenticationFilter & BasicAuthenticationEntryPoint as strategy -->
+        <security:http-basic/>
 
-		<security:intercept-url pattern="/admin/**/*" access="ROLE_ADMIN" />
+		<security:intercept-url pattern="/admin/**/*"
+			access="ROLE_ADMIN" />
 	</security:http>
+
+
 
 	<security:authentication-manager>
 		<security:authentication-provider>
@@ -17,5 +28,9 @@
 			</security:user-service>
 		</security:authentication-provider>
 	</security:authentication-manager>
+
+
+    <!-- Beans -->
+    <bean id="serverErrorHandler" class="com.terrormovies.web.security.ServerErrorFailureHandler"/>
 
 </beans>


### PR DESCRIPTION
- Authentication based on hashing of user-name:password within the HTTP header - `authorization`.
- Useful when no human based authentication is required.

Content:
- Updated security bean config to replace login-form based authentication with basic-authentication
- Added custom handler for failed authentication request.