### PR TITLE
Partial RememberMe Authentication

### DIFF
--- a/terror-movies-web/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/terror-movies-web/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -7,7 +7,7 @@
 	<security:http auto-config="true" entry-point-ref="digestEntryPoint">
  -->
 
-    <security:http auto-config="true">
+    <security:http auto-config="true" access-decision-manager-ref="accessDecisionManager">
 
        <!-- Configuration for form login authentication -->
 <!-- 
@@ -28,7 +28,7 @@
         <security:custom-filter ref="digestFilter" before="BASIC_AUTH_FILTER"/>
  -->
 
-		<security:intercept-url pattern="/admin/**/*" access="ROLE_ADMIN" />
+		<security:intercept-url pattern="/admin/*" access="ROLE_ADMIN,IS_AUTHENTICATED_FULLY" />
 	</security:http>
 
 
@@ -43,6 +43,16 @@
 
 
     <!-- Beans -->
+
+    <!-- Access Decision Manager -->
+    <bean id="accessDecisionManager" class="org.springframework.security.access.vote.UnanimousBased">
+        <constructor-arg>
+            <list>
+                <bean class="org.springframework.security.access.vote.RoleVoter"/>
+                <bean class="org.springframework.security.access.vote.AuthenticatedVoter"/>
+            </list>
+        </constructor-arg>
+    </bean>
 
     <bean id="serverErrorHandler" class="com.terrormovies.web.security.ServerErrorFailureHandler"/>
 


### PR DESCRIPTION
- RememberMe authentication with UnanimousAccessDecisionManager with URLs protected rule - IS_FULLY_AUTHENTICATED is allowing RememberMe authentication type to part of the application.

Content:
- [security-context]: added UnanimousAccessDecisionManager
- [security-context]: added URL access rule with IS_FULLY_AUTHENTICATED access